### PR TITLE
[ADD] ajout d'un path de redirection pour l'option debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ EVALSRCS += tools_var.c
 EVALSRCS += tools_redir.c
 EVALSRCS += tools_termios.c
 EVALSRCS += errors_handling.c
+EVALSRCS += debug.c
 
 ## JOB CONTROL ##
 

--- a/includes/exec.h
+++ b/includes/exec.h
@@ -100,5 +100,7 @@ void		process_type(t_process *p);
 void		routine_clean_job(void *del, size_t u);
 void	del_struct_process(void *del, size_t u);
 
+/*		DEBUG */
+void	debug_print_all(t_job *j, t_list *process, char *where);
 
 #endif

--- a/includes/sh.h
+++ b/includes/sh.h
@@ -19,8 +19,8 @@ void	ex(char *s); //pour la gestion des erreurs amenant a quiter
 void		ft_ex(char *error);
 void		clean_cfg(t_cfg *shell);
 void		set_signal_ign(void);
-uint8_t		init_shell(char **env, char **av);
-t_cfg		*init_cfg(char **env, char **av);
+void		init_shell(char **env, char **av, int ac);
+t_cfg		*init_cfg(char **env, char **av, int ac);
 t_cfg		*cfg_shell(void);
 
 /*	COMMON TOOLS */

--- a/srcs/builtins/env.c
+++ b/srcs/builtins/env.c
@@ -95,6 +95,8 @@ uint8_t			ft_env(t_job *j, t_process *p)
 		routine_clean_job(j_cpy, sizeof(t_job));
 		ft_memdel((void **)&j_cpy);
 	}
+	if (shell_cpy.debug)
+		shell_cpy.debug = 1;
 	clean_cfg(&shell_cpy);
 	return (ret);
 }

--- a/srcs/evaluator/cleaner.c
+++ b/srcs/evaluator/cleaner.c
@@ -48,5 +48,7 @@ void	clean_cfg(t_cfg *shell)
 	ft_lstdel(&shell->env, del_struct_tvar);
 	ft_lstdel(&shell->intern, del_struct_tvar);
 	ft_lstdel(&shell->job, del_struct_job);
+	if (shell->debug > 2)
+		close(shell->debug);
 	ft_bzero(shell, sizeof(t_cfg));
 }

--- a/srcs/evaluator/debug.c
+++ b/srcs/evaluator/debug.c
@@ -1,0 +1,26 @@
+#include "ft_printf.h"
+#include "struct.h"
+#include "sh.h"
+
+void	debug_print_all(t_job *j, t_list *process, char *where)
+{
+	t_cfg		*shell;
+	t_process	*p;
+
+	shell = cfg_shell();
+	ft_dprintf(shell->debug, "\n\n-----------\t [DEBUG] Print all\t %s\n", where);
+	ft_dprintf(shell->debug, "\t[PROCESS]\n");
+
+	while (process)
+	{
+		p = process->data;
+		ft_dprintf(shell->debug, "CMD = [%s]\tPATH = [%s]\n", p->cmd, p->path);
+		ft_dprintf(shell->debug, "SETUP = [%032b]\n", p->setup);
+		ft_dprintf(shell->debug, "STATUS = [%08b]\n", p->status);
+		process = process->next;
+	}
+	ft_dprintf(shell->debug, "\t[JOB]\n");
+	ft_dprintf(shell->debug, "CMD = [%s]\tID = [%d]\tFG = [%d]\n", j->cmd, j->id, j->fg);
+	ft_dprintf(shell->debug, "STATUS = [%08b]\tRET = [%d]\n", j->status, j->ret);
+	ft_dprintf(shell->debug, "-----------\n", where);
+}

--- a/srcs/evaluator/leveling.c
+++ b/srcs/evaluator/leveling.c
@@ -60,10 +60,10 @@ uint8_t		ft_eval(t_list *cmd_table)
 
 	shell = cfg_shell();
 	if (shell->debug)
-		ft_printf("\n\n----------- eval -----------\n\n\n\n");
+		ft_dprintf(shell->debug, "\n\n--------- EVAL ----------\n\n");
 	set_signal_ign();
 	lvl_cmd_table(shell, cmd_table);
 	if (shell->debug)
-		ft_printf("----------- eval -----------\n\n");
+		ft_dprintf(shell->debug, "---------- EVAL ----------\n\n");
 	return (0);
 }

--- a/srcs/evaluator/wait.c
+++ b/srcs/evaluator/wait.c
@@ -113,27 +113,8 @@ void		wait_process(t_job *job)
 			stopped = TRUE;
 	}
 	update_job(job, stopped);
-
-
-
-
-	/* DEBUG  */
-	t_cfg *shell = cfg_shell();
-	if (shell->debug)
-	{
-		t_process *process;
-		t_list *j = job->process;
-		printf("\n\n ----------------------\n--> [INFO PROCESS] \n");
-		while (j)
-		{
-			process = j->data;
-			printf("path = [%s]\t retour = [%d]\t status = [%d]\n", process->path, process->ret, process->status);
-			j = j->next;
-		}
-		printf("--> [INFO JOB] \n");
-		printf("\tJOB status = [%d]\t  JOB return = [%d]\n ----------------------\n\n", job->status, job->ret);
-	}
-	/*		*/
+	if (cfg_shell()->debug)
+		debug_print_all(job, job->process, "wait ending");
 	return ;
 }
 

--- a/srcs/init_cfg.c
+++ b/srcs/init_cfg.c
@@ -2,7 +2,7 @@
 #include "libft.h"
 #include "sh.h"
 #include "var.h"
-
+#include "ft_printf.h"
 
 static void	set_var_intern(t_cfg *shell)
 {
@@ -25,17 +25,28 @@ static void	set_var_intern(t_cfg *shell)
 
 static uint8_t		set_debug(char **av)
 {
-	int i;
+	int 	i;
+	int		fd;
+	char	*path;
 
-	i = 1;
-	while (av[i])
-		if (!ft_strcmp(av[i++], "debug"))
-			return (1);
-	return (0);
+	i = 0;
+	while (i++ && av[i])
+		if (!ft_strcmp(av[i], "debug"))
+			break ;
+	if (!av[i])
+		return (0);
+	if (!av[i + 1] || *av[i + 1] != '-')
+		return (1);
+	path = (av[i + 1]) + 1;
+	if ((fd = open(path, O_CREAT | O_WRONLY, 0644)) == -1)
+	{
+		ft_dprintf(2, "Debug option error\n\tusage: ./21sh debug [-path]\nexit\n");
+		exit(1);
+	}
+	return (fd);
 }
 
-
-t_cfg		*init_cfg(char **env, char **av)
+t_cfg		*init_cfg(char **env, char **av, int ac)
 {
 	t_cfg	*shell;
 
@@ -45,7 +56,7 @@ t_cfg		*init_cfg(char **env, char **av)
 	create_lst_var(&shell->env, env);
 	ft_setvar(&shell->env, "PROJECT", "21sh");
 	set_var_intern(shell);
-	shell->debug = set_debug(av);
+	if (ac > 1)
+		shell->debug = set_debug(av);
 	return (shell);
 }
-

--- a/srcs/init_shell.c
+++ b/srcs/init_shell.c
@@ -13,10 +13,8 @@ static int	check_terminal(t_cfg *cfg, uint8_t tty)
 {
 	if (cfg && (cfg->interactive = isatty(tty)))
 	{
-/*		if (!(cfg->term_origin = malloc(sizeof(struct termios))))
-			ft_ex("[Fatal Error] MALLOC\nexit\n"); */
 		if ((tcgetattr(tty, &cfg->term_origin) == FALSE))
-			perror("[TERM ORIGIN] ERROR TCGETATTR");
+			perror("[TERM ORIGIN] ERROR TCGETATTR"); ///perror
 		return (1);
 	}
 	return (0);
@@ -32,7 +30,6 @@ void		set_signal_ign(void)
 //	signal(SIGCHLD, SIG_IGN); //for job control
 }
 
-
 t_cfg		*cfg_shell(void)
 {
 	static t_cfg shell;
@@ -41,7 +38,7 @@ t_cfg		*cfg_shell(void)
 }
 
 
-uint8_t		init_shell(char **env, char **av)
+void		init_shell(char **env, char **av, int ac)
 {
 	uint8_t		shell_terminal;
 	pid_t		shell_pgid;
@@ -50,7 +47,7 @@ uint8_t		init_shell(char **env, char **av)
 
 	if (fstat((shell_terminal = ttyslot()), &stat) == -1)
 		ft_ex("file descriptor stdin close\nbad file descriptor\nexit");
-	shell = init_cfg(env, av);
+	shell = init_cfg(env, av, ac);
 	if (check_terminal(shell, shell_terminal))
 	{
 		while (tcgetpgrp(shell_terminal) != (shell_pgid = getpgrp()))
@@ -61,5 +58,4 @@ uint8_t		init_shell(char **env, char **av)
 		if (tcsetpgrp(shell_terminal, shell->pid))
 			perror("[INIT SHELL] error tcsetpgrp");
 	}
-	return (shell->debug);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -91,8 +91,7 @@ int		main(int ac, char **av, char **env)
 	t_lexer		lexer;
 	t_parser	parser;
 
-	init_shell(env, av);
-	(void)ac;
+	init_shell(env, av, ac);
 	while (1)
 	{
 		if ((ret = line_edition_routine(&line)) <= 0
@@ -108,6 +107,7 @@ int		main(int ac, char **av, char **env)
 			}
 		}
 	}
+	clean_cfg(cfg_shell());
 	exit(0);
 	/*The shell exits by default upon receipt of a SIGHUP. Before exiting, an interactive shell resends the SIGHUP to all jobs, running or stopped. Stopped jobs are sent SIGCONT to ensure that they receive the SIGHUP. */
 }


### PR DESCRIPTION
New feature
./21sh debug [-path]

l'option debug peut prendre une option path.
shell->debug prend la valeur de retour de open

exemple :
./21sh debug 
   => debug = STDIN
./21sh debug -path
  => debug = fd de path
./21sh debug -/dev/pts/x
  => pour ecrire sur un autre terminal