### PR TITLE
[fix] memset int8 par int16 pour env env ou job en bg

### DIFF
--- a/srcs/builtins/env.c
+++ b/srcs/builtins/env.c
@@ -58,10 +58,10 @@ t_job			*create_new_instance(t_cfg *shell_cpy, t_job *j, t_process *p, int32_t a
 	ft_bzero(&p_cpy, sizeof(t_process));
 	p_cpy.cmd = ft_strdup(*(p->av+ac));
 	p_cpy.av = ft_tabdup(p->av+ac);
-	ft_memset(p_cpy.std, -1, (sizeof(int8_t) * 3));
+	ft_memset(p_cpy.std, -1, (sizeof(int16_t) * 3));
 	j_cpy->cmd = ft_strdup(j->cmd);
 	j_cpy->pgid = j->pgid;
-	ft_memset(j_cpy->std, -1, (sizeof(int8_t) * 3));
+	ft_memset(j_cpy->std, -1, (sizeof(int16_t) * 3));
 	j_cpy->fg = j->fg;
 	ft_lst_push_back(&j_cpy->process, &p_cpy, sizeof(t_process));
 	shell = cfg_shell();

--- a/srcs/job_control/tools_job.c
+++ b/srcs/job_control/tools_job.c
@@ -66,6 +66,6 @@ void          	ft_cpy_job(t_job *job, t_job *copy)
 	copy->status = job->status;
 	copy->ret = job->ret;
 	copy->id = job->id;
-	ft_memset(copy->std, -1, sizeof(uint8_t) * 3);
+	ft_memset(copy->std, -1, sizeof(int16_t) * 3);
 	ft_memcpy(&copy->term_eval, &job->term_eval, sizeof(job->term_eval));
 }


### PR DESCRIPTION
[FIX] jobs en bg 
[FIX] env env 

taille du memset etait inchangée uint8_t > int16_t